### PR TITLE
Ungroup measurements in mkeys

### DIFF
--- a/cddl/corim-frags.mk
+++ b/cddl/corim-frags.mk
@@ -1,10 +1,12 @@
 CORIM_FRAGS += crypto-key-type-choice-ext.cddl
 CORIM_FRAGS += digest.cddl
 CORIM_FRAGS += non-empty.cddl
+CORIM_FRAGS += semver-version-map.cddl
 CORIM_FRAGS += sevsnpvm-guest-policy-flags-ext.cddl
 CORIM_FRAGS += sevsnpvm-version-scheme-ext.cddl
 CORIM_FRAGS += sevsnpvm-vmpl-raw-value-ext.cddl
 CORIM_FRAGS += sevsnphost-platform-info-flags-ext.cddl
+CORIM_FRAGS += sized-tagged-bytes.cddl
 CORIM_FRAGS += svn-type-choice.cddl
 CORIM_FRAGS += svn64-type.cddl
 CORIM_FRAGS += uint16.cddl

--- a/cddl/examples/current-version.diag
+++ b/cddl/examples/current-version.diag
@@ -1,0 +1,4 @@
+/ version: / 0: / version-map / {
+  / version: / 0: "1.55.20"
+  / version-scheme: / 16384
+}

--- a/cddl/semver-version-map.cddl
+++ b/cddl/semver-version-map.cddl
@@ -1,0 +1,5 @@
+semver-version-map = {
+  &(version: 0): version-core-text,
+  &(version-scheme: 1): &(semver: 16384)
+}
+version-core-text = tstr .regexp "[0-9]+\\.[0-9]+\\.[0-9]+"

--- a/cddl/sized-tagged-bytes.cddl
+++ b/cddl/sized-tagged-bytes.cddl
@@ -1,0 +1,16 @@
+tagged-byte = #6.560(bytes1)
+tagged-leuint32 = #6.560(bytes4)
+tagged-leuint64 = #6.560(bytes8)
+tagged-bytes4   = #6.560(bytes4)
+tagged-bytes8   = #6.560(bytes8)
+tagged-bytes32  = #6.560(bytes16)
+tagged-bytes32  = #6.560(bytes32)
+tagged-bytes64  = #6.560(bytes64)
+bytes1  = bytes .size 1
+bytes2  = bytes .size 2
+bytes4  = bytes .size 4
+bytes8  = bytes .size 8
+bytes16 = bytes .size 16
+bytes32 = bytes .size 32
+bytes48 = bytes .size 48
+bytes64 = bytes .size 64


### PR DESCRIPTION
This also changes the mkey numbering convention to be more future-proof to allow for any bit-specific fields to have their own mkey.

What still could be better is to request standard extensions to the flags-map to individually name GUEST_POLICY and PLATFORM_INFO flags, but I leave that to a later PR.