### PR TITLE
Remove the model field from the environment-map

### DIFF
--- a/cddl/examples/environment.diag
+++ b/cddl/examples/environment.diag
@@ -1,6 +1,6 @@
 / environment-map / {
   / class-map / {
-    / class-id: / 0 => #6.111(1.3.6.1.4.1.3704.2.1)
+    / class-id: / 0 => #6.111(h'06092b060104019c780301')
   }
   / instance: / 1 => #6.560(CHIP_ID)
 }

--- a/cddl/examples/profile.diag
+++ b/cddl/examples/profile.diag
@@ -1,6 +1,6 @@
 / corim-map / {
   / corim.profile / 3: [
-    32("http://amd.com/please-permalink-me")
+    32("tag:amd.com,2024/snp-corim-profile")
   ]
   / ... /
 }

--- a/cddl/examples/vcek-triple.diag
+++ b/cddl/examples/vcek-triple.diag
@@ -1,7 +1,6 @@
 [ / environment-map / {
     &(class: 0): / class-map / {
-      &(class-id: 0): 37(h'd05e6d1b9f464ae2a610ce3e6ee7e153'),
-      &(model: 2): "Genoa"
+      &(class-id: 0): 111(h'06092b060104019c780301'),
     },
     &(instance: 2): 560(hwid)
   },

--- a/cddl/examples/vlek-triple.diag
+++ b/cddl/examples/vlek-triple.diag
@@ -1,7 +1,6 @@
 [ / environment-map / {
     &(class: 0): / class-map / {
-      &(class-id: 0): 37(h'89a7a1f0e7044faaacbd81c86df8a961'),
-      &(model: 2): "Milan"
+      &(class-id: 0): 111(h'06092b060104019c780302'),
     },
     &(instance: 2): 560(csp_id)
   },

--- a/draft-deeglaze-amd-sev-snp-corim-profile.md
+++ b/draft-deeglaze-amd-sev-snp-corim-profile.md
@@ -33,6 +33,11 @@ contributor:
   email: yogesh.deshpande@arm.com
   contribution: >
       Yogesh Deshpande contributed to the data model by providing advice about CoRIM founding principles.
+- ins: B. Jacobs
+  name: Bill Jacobs
+  organization: Advanced Micro Devices
+  contribution: >
+      Bill contributed a review and the OID assignments on behalf of AMD.
 
 normative:
   RFC4122:
@@ -459,11 +464,6 @@ A [VLEK] certificate SHALL be associated with an environment with a "by CSP" `cl
 
 It is expected that the Verifier will require or admit a trust anchor that associates the AMD root key and AMD SEV key certificates for a `product_name` (from KDS endpoint `vcek/v1/{product_name}/cert_chain` or `vlek/v1/{product_name}/cert_chain`) with the appropriate environment class in order to validate the attestation key certificates.
 If using a CoTS {{-ta-store}} tag for trust anchor specification, an appropriate `purpose` for verifying a VEK cerificate is `"eat"`.
-
-# TCG considerations
-
-The Trusted Computing Group has standardized the PCClient Platform Firmware Profile to specify expected TPM event log processing.
-Since AMD SEV-SNP launch measurements are of virtual firmware, they can supplement the `EV_POST_CODE2` event measured into PCR0 for the `EV_EFI_PLATFORM_FIRMWARE_BLOB2` since the bits of the firmware are more specific than embedded firmware version strings.
 
 # IANA Considerations
 

--- a/draft-deeglaze-amd-sev-snp-corim-profile.md
+++ b/draft-deeglaze-amd-sev-snp-corim-profile.md
@@ -144,7 +144,8 @@ VEK:
 
 AMD SEV-SNP launch endorsements are carried in one or more CoMIDs inside a CoRIM.
 
-The profile attribute in the CoRIM MUST be present and MUST have a single entry set to the URI http://amd.com/please-permalink-me as shown in {{figure-profile}}.
+The profile attribute in the CoRIM MAY be present to specify a further restriction on this profile.
+The base requirements of this profile MAY be specified by `tag:amd.com,2024:snp-corim-profile` {{figure-profile}}.
 
 ~~~ cbor-diag
 {::include cddl/examples/profile.diag}
@@ -174,8 +175,7 @@ The `class-id` for the Target Environment measured by the AMD-SP is a tagged OID
 *  By chip: 1.3.6.1.4.1.3704.3.1 (`111(h'06092b060104019c780301')`)
 *  By CSP: 1.3.6.1.4.1.3704.3.2 (`111(h'06092b060104019c780302')`)
 
-The `&(model: 2)` field of the `class-map` is specific to the product name of the chip as determined by the family/model (not stepping) value.
-The text for `model` MUST be the `product_name` specified in the [VCEK] specification, e.g., "Milan" or "Genoa".
+The `model` field MUST NOT be present in the `environment-map`, as it is error-prone to determine for VERSION 2, and redundant with fields added in VERSION 3.
 
 The rest of the `class-map` MUST remain empty, since `class` is compared for deterministic CBOR binary encoding equality.
 
@@ -199,7 +199,7 @@ The measurements in an ATTESTATION_REPORT are each assigned an `mkey` value and 
 The convention for `mkey` value assignment is to sequential ordering when there are no reserved bits.
 The `mkey` following a reserved bit is the bit position in the report of the start of the value.
 The `R[lo:hi]` notation will reference the attestation report byte slice from offset `lo` inclusive to `hi` exclusive.
-The `leuint(slice)` function translates a byte string in little endian to its `uint` representation.
+The `leuintN` type is another name for a byte string, but with the interpretation that it represents an unsigned integer with `N` bit width.
 
 **mkey 0**: VERSION.
 Expressed as `&(raw-value: 4): tagged-leuint32`.
@@ -237,7 +237,7 @@ Expressed as `&(raw-value: 4): tagged-bytes64`.
 **mkey 641**: MEASUREMENT.
 Expressed as `&(digests: 2): [[7, bytes48]]`.
 
-**mkey 642: HOST_DATA.
+**mkey 642**: HOST_DATA.
 Expressed as `&(digests: 2): [[7, bytes48]]`.
 
 **mkey 643**: ID_KEY_DIGEST.
@@ -296,6 +296,8 @@ If `SIGNING_KEY` is 1
 
 *  The `environment-map / class / class-id` field SHALL be set to `37(h'89a7a1f0e7044faaacbd81c86df8a961')`.
 *  The `environment-map / instance ` field SHALL be `560(CSP_ID)`.
+
+The Verifier is free add a `group` according to vendor-defined rules.
 
 #### `measurement-map`
 The translation makes use of the following metafunctions:
@@ -381,7 +383,7 @@ The codepoint `&(raw-value: 4)` SHALL be set to `560(R[0x188:0x189])` only if VE
 The codepoint `&(raw-value: 4)` SHALL be set to `560(R[0x189:0x18A])` only if VERSION (little endian `R[0x000:0x004]`) is at least 3.
 
 **mkey 650**: CPUID_STEP.
-The codepoint `&(raw-value: 4)` SHALL be set to `560(R[0x18A:0x18B])` only if VERSION (little endian `R[0x000:0x004]`)is at least 3.
+The codepoint `&(raw-value: 4)` SHALL be set to `560(R[0x18A:0x18B])` only if VERSION (little endian `R[0x000:0x004]`) is at least 3.
 
 **mkey 3328**: CHIP_ID.
 The codepoint `&(raw-value: 4)` SHALL be set to `560(R[0x1A0:0x1E0])` only if MASK_CHIP_KEY (`R[0x048] & 2`) is 0.


### PR DESCRIPTION
Some fixups to class-id given AMD's new OID assignments.