### PR TITLE
Add some richer types to prior raw-values

### DIFF
--- a/cddl/corim-autogen.cddl
+++ b/cddl/corim-autogen.cddl
@@ -5,6 +5,12 @@ digest = [
   val: bytes
 ]
 
+int-version-map = {
+  &(version: 0): version-int-text,
+  &(version-scheme: 1): &(multipartnumeric: 1)
+}
+version-int-text = tstr .regexp "[0-9]+"
+
 non-empty<M> = (M) .and ({ + any => any })
 
 semver-version-map = {
@@ -61,6 +67,10 @@ min-svn = svn-type
 tagged-svn = #6.552(svn)
 tagged-min-svn = #6.553(min-svn)
 svn-type-choice = tagged-svn / tagged-min-svn
+
+svn32-type = tagged-svn32 / tagged-min-svn32
+tagged-svn32 = #6.552(uint32)
+tagged-min-svn32 = #6.553(uint32)
 
 svn64-type = tagged-svn64 / tagged-min-svn64
 tagged-svn64 = #6.552(uint64)

--- a/cddl/corim-frags.mk
+++ b/cddl/corim-frags.mk
@@ -1,5 +1,6 @@
 CORIM_FRAGS += crypto-key-type-choice-ext.cddl
 CORIM_FRAGS += digest.cddl
+CORIM_FRAGS += int-version-map.cddl
 CORIM_FRAGS += non-empty.cddl
 CORIM_FRAGS += semver-version-map.cddl
 CORIM_FRAGS += sevsnpvm-guest-policy-flags-ext.cddl
@@ -8,6 +9,7 @@ CORIM_FRAGS += sevsnpvm-vmpl-raw-value-ext.cddl
 CORIM_FRAGS += sevsnphost-platform-info-flags-ext.cddl
 CORIM_FRAGS += sized-tagged-bytes.cddl
 CORIM_FRAGS += svn-type-choice.cddl
+CORIM_FRAGS += svn32-type.cddl
 CORIM_FRAGS += svn64-type.cddl
 CORIM_FRAGS += uint16.cddl
 CORIM_FRAGS += uint32.cddl

--- a/cddl/int-version-map.cddl
+++ b/cddl/int-version-map.cddl
@@ -1,0 +1,5 @@
+int-version-map = {
+  &(version: 0): version-int-text,
+  &(version-scheme: 1): &(multipartnumeric: 1)
+}
+version-int-text = tstr .regexp "[0-9]+"

--- a/cddl/svn32-type.cddl
+++ b/cddl/svn32-type.cddl
@@ -1,0 +1,3 @@
+svn32-type = tagged-svn32 / tagged-min-svn32
+tagged-svn32 = #6.552(uint32)
+tagged-min-svn32 = #6.553(uint32)

--- a/draft-deeglaze-amd-sev-snp-corim-profile.md
+++ b/draft-deeglaze-amd-sev-snp-corim-profile.md
@@ -201,11 +201,11 @@ The `mkey` following a reserved bit is the bit position in the report of the sta
 The `R[lo:hi]` notation will reference the attestation report byte slice from offset `lo` inclusive to `hi` exclusive.
 The `leuintN` type is another name for a byte string, but with the interpretation that it represents an unsigned integer with `N` bit width.
 
-**mkey 0**: VERSION.
-Expressed as `&(raw-value: 4): tagged-leuint32`.
+**mkey 0**: VERSION. This is the ATTESTATION_REPORT ABI version, not to be confused with CurrentVersion or CommittedVersion that describe the SEV-SNP firmware version.
+Expressed as `&(version: 0): int-version-map`.
 
 **mkey 1**: GUEST_SVN.
-Expressed as `&(raw-value: 4): tagged-bytes4`.
+Expressed as `&(svn: 1): svn32-type`.
 
 **mkey 2**: POLICY.
 Expressed as `&(raw-value: 4): tagged-bytes8` with optional `&(raw-value-mask: 5): tagged-bytes8` to restrict the reference value to the masked bits.
@@ -218,11 +218,12 @@ Expressed as `&(raw-value: 4): tagged-bytes16`.
 
 **mkey 5**: VMPL.
 Expressed as `&(raw-value: 4): tagged-leuint32`.
+_Would prefer a [privilege level measurement type](https://github.com/ietf-rats-wg/draft-ietf-rats-corim/pull/354)_
 
 **SIGNATURE_ALGO skipped**: `R[0x034:0x38]` only needed for signature verification.
 
 **mkey 6**: CURRENT_TCB.
-Expressed as `&(svn: 1): svn-type .and svn64-type`
+Expressed as `&(svn: 1): svn64-type`
 
 **mkey 7**: PLATFORM_INFO.
 Expressed as `&(raw-value: 4): tagged-bytes8` with optional `&(raw-value-mask: 5): tagged-bytes8` to restrict the reference value to the masked bits.
@@ -302,7 +303,8 @@ The Verifier is free add a `group` according to vendor-defined rules.
 #### `measurement-map`
 The translation makes use of the following metafunctions:
 
-*  The function `dec(b)` represents a byte in its decimal string rendering.
+*  The function `dec(b)` represents a number in its decimal string rendering.
+*  The functions `leuintN(bstr)` translates a byte string representing `N` bits in little-endian into a CBOR integer.
 
 Juxtaposition of expressions with string literals is interpreted with string concatenation.
 
@@ -318,11 +320,11 @@ The `&(flags: 3)` codepoint SHALL be set to a `flags-map` with the following con
 *  `is-debug` SHALL be set to the truth value of bit 19 of `POLICY`.
 
 **mkey 0**: VERSION.
-The codepoint `&(raw-value: 4)` SHALL be set to `560(R[0x000:0x004])`.
+The codepoint `&(version: 0)` SHALL be set to `{ / version: / 0: vstr, / version-scheme: / 1: / decimal / 4}` where `vstr` is constructed as `dec(leuint32(R[0x000:0x004]))`.
 
 **mkey 1**: GUEST_SVN.
 4 bytes.
-The codepoint `&(raw-value: 4)` SHALL be set to `560(R[0x004:0x008])`.
+The codepoint `&(svn: 1)` SHALL be set to `leuint32(R[0x004:0x008])`.
 
 **mkey 2**: POLICY.
 8 bytes.


### PR DESCRIPTION
There was some pushback in the working group about these types. The VMPL is still a raw value because there's no linear privilege level measurement type.